### PR TITLE
Remove unused vars checking

### DIFF
--- a/mellon_create_metadata.sh
+++ b/mellon_create_metadata.sh
@@ -17,16 +17,7 @@ if [ "$#" -lt 2 ]; then
 fi
 
 ENTITYID="$1"
-if [ -z "$ENTITYID" ]; then
-    echo "$PROG: An entity ID is required." >&2
-    exit 1
-fi
-
 BASEURL="$2"
-if [ -z "$BASEURL" ]; then
-    echo "$PROG: The URL to the MellonEndpointPath is required." >&2
-    exit 1
-fi
 
 if ! echo "$BASEURL" | grep -q '^https\?://'; then
     echo "$PROG: The URL must start with \"http://\" or \"https://\"." >&2


### PR DESCRIPTION
The length of the 2 vars ENTITYID and BASEURL can't be zero since there is a control before 'if [ "$#" -lt 2 ]'.